### PR TITLE
Fix cluster role of controller-manager

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -12,4 +12,5 @@ rules:
   - applications
   verbs:
   - get
+  - list
   - watch

--- a/controllers/application_controller.go
+++ b/controllers/application_controller.go
@@ -37,7 +37,7 @@ type ApplicationReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=argoproj.io,resources=applications,verbs=get;watch
+// +kubebuilder:rbac:groups=argoproj.io,resources=applications,verbs=get;watch;list
 
 func (r *ApplicationReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()


### PR DESCRIPTION
This will fix the following error:

```
E0204 01:40:30.942946       1 reflector.go:127] pkg/mod/k8s.io/client-go@v0.19.2/tools/cache/reflector.go:156: Failed to watch *v1alpha1.Application: failed to list *v1alpha1.Application: applications.argoproj.io is forbidden: User "system:serviceaccount:argocd-commenter-system:default" cannot list resource "applications" in API group "argoproj.io" at the cluster scope
```