### PR TITLE
Fix duplicated healthy notifications

### DIFF
--- a/controllers/argocd.go
+++ b/controllers/argocd.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 
+	argocdv1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -20,4 +21,14 @@ func findArgoCDURL(ctx context.Context, c client.Client, namespace string) strin
 		return ""
 	}
 	return cm.Data["url"]
+}
+
+func getLastDeployedRevision(a argocdv1alpha1.Application) string {
+	if a.Status.OperationState == nil {
+		return ""
+	}
+	if a.Status.OperationState.Operation.Sync == nil {
+		return ""
+	}
+	return a.Status.OperationState.Operation.Sync.Revision
 }


### PR DESCRIPTION
Eventually the controller posts duplicated comments for health of a revision. It should use `Status.OperationState.Operation.Sync.Revision` instead of `Status.Sync.Revision`.