### PR TITLE
Fix nil panic if Application has no annotations

### DIFF
--- a/controllers/annotation.go
+++ b/controllers/annotation.go
@@ -17,6 +17,9 @@ func patchAnnotation(ctx context.Context, c client.Client, a argocdv1alpha1.Appl
 	patch.SetNamespace(a.Namespace)
 	patch.SetName(a.Name)
 	annotations := a.DeepCopy().Annotations
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
 	f(annotations)
 	patch.SetAnnotations(annotations)
 


### PR DESCRIPTION
The controller caused a crash loop due to the following error:

```
panic: assignment to entry in nil map

goroutine 310 [running]:
github.com/int128/argocd-commenter/controllers.(*ApplicationHealthStatusReconciler).Reconcile.func1(0xc000293180)
	/workspace/controllers/applicationhealthstatus_controller.go:57 +0x45
github.com/int128/argocd-commenter/controllers.patchAnnotation({_, _}, {_, _}, {{{0x19a656a, 0xb}, {0xc0031791b8, 0x14}}, {{0xc003293dd4, 0x9}, ...}, ...}, ...)
	/workspace/controllers/annotation.go:20 +0x1c3
github.com/int128/argocd-commenter/controllers.(*ApplicationHealthStatusReconciler).Reconcile(0xc0009fa120, {0x2116e78, 0xc003ae5200}, {{{0xc003293dea, 0x1ce94c0}, {0xc003293dd4, 0xc00066c680}}})
	/workspace/controllers/applicationhealthstatus_controller.go:56 +0x1f3
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0xc000949b80, {0x2116e78, 0xc003ae5170}, {{{0xc003293dea, 0x1ce94c0}, {0xc003293dd4, 0xc0009e9580}}})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.10.1/pkg/internal/controller/controller.go:114 +0x222
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000949b80, {0x2116dd0, 0xc0006fa400}, {0x1c326a0, 0xc0015176c0})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.10.1/pkg/internal/controller/controller.go:311 +0x2f2
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000949b80, {0x2116dd0, 0xc0006fa400})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.10.1/pkg/internal/controller/controller.go:266 +0x205
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.10.1/pkg/internal/controller/controller.go:227 +0x85
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.10.1/pkg/internal/controller/controller.go:223 +0x354
```

I think nil map error occurs if an `Application` does not have any `annotations`.