### PR TITLE
Filter pull requests by changed files on comment

### DIFF
--- a/pkg/github/comment.go
+++ b/pkg/github/comment.go
@@ -14,18 +14,13 @@ type Comment struct {
 	Body       string
 }
 
-func (c *client) CreateComment(ctx context.Context, r Repository, revision, body string) error {
-	pulls, _, err := c.rest.PullRequests.ListPullRequestsWithCommit(ctx, r.Owner, r.Name, revision, nil)
-	if err != nil {
-		return fmt.Errorf("could not list pull requests with commit: %w", err)
-	}
-
+func (c *client) CreateComment(ctx context.Context, r Repository, pulls []int, body string) error {
 	var errs []string
 	for _, pull := range pulls {
-		_, _, err := c.rest.Issues.CreateComment(ctx, r.Owner, r.Name, pull.GetNumber(),
+		_, _, err := c.rest.Issues.CreateComment(ctx, r.Owner, r.Name, pull,
 			&github.IssueComment{Body: github.String(body)})
 		if err != nil {
-			errs = append(errs, fmt.Sprintf("pull request #%d: %s", pull.GetNumber(), err))
+			errs = append(errs, fmt.Sprintf("pull request #%d: %s", pull, err))
 		}
 	}
 	if len(errs) > 0 {

--- a/pkg/github/pull.go
+++ b/pkg/github/pull.go
@@ -1,0 +1,26 @@
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+func (c *client) ListPullRequests(ctx context.Context, r Repository, revision string) ([]PullRequest, error) {
+	ghPulls, _, err := c.rest.PullRequests.ListPullRequestsWithCommit(ctx, r.Owner, r.Name, revision, nil)
+	if err != nil {
+		return nil, fmt.Errorf("could not list pull requests with commit: %w", err)
+	}
+	var pulls []PullRequest
+	for _, pr := range ghPulls {
+		prFiles, _, err := c.rest.PullRequests.ListFiles(ctx, r.Owner, r.Name, pr.GetNumber(), nil)
+		if err != nil {
+			return nil, fmt.Errorf("could not list files of pull request #%d: %w", pr.GetNumber(), err)
+		}
+		var files []string
+		for _, f := range prFiles {
+			files = append(files, f.GetFilename())
+		}
+		pulls = append(pulls, PullRequest{Number: pr.GetNumber(), Files: files})
+	}
+	return pulls, nil
+}

--- a/pkg/github/types.go
+++ b/pkg/github/types.go
@@ -6,7 +6,8 @@ import (
 )
 
 type Client interface {
-	CreateComment(ctx context.Context, r Repository, revision, body string) error
+	ListPullRequests(ctx context.Context, r Repository, revision string) ([]PullRequest, error)
+	CreateComment(ctx context.Context, r Repository, pulls []int, body string) error
 	CreateDeploymentStatus(ctx context.Context, d Deployment, ds DeploymentStatus) error
 }
 
@@ -23,4 +24,9 @@ func ParseRepositoryURL(s string) *Repository {
 		return nil
 	}
 	return &Repository{Owner: m[1], Name: m[2]}
+}
+
+type PullRequest struct {
+	Number int
+	Files  []string
 }


### PR DESCRIPTION
This adds a feature to determine if a pull request is related to a sync or healthy event. It will prevent a comment to unrelated pull request.