### PR TITLE
bump deployment manifest to release 1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Argo CD is running in your Kubernetes cluster.
 To deploy the manifest:
 
 ```shell
-kubectl apply -f https://github.com/int128/argocd-commenter/releases/download/v0.3.0/argocd-commenter.yaml
+kubectl apply -f https://github.com/int128/argocd-commenter/releases/download/v1.8.0/argocd-commenter.yaml
 ```
 
 You need to create either Personal Access Token or GitHub App.


### PR DESCRIPTION
Hey folks

Many thanks for this project - looks awesome!

I followed the README which still installs a very old version 0.3.0 - so I hit some bugs that were already fixed. It would be cool if we could bump the link in the README, so that the newest version is installed.