### PR TITLE
force apply patching to fix conflicts with argocd-notification

### DIFF
--- a/controllers/annotation.go
+++ b/controllers/annotation.go
@@ -24,5 +24,9 @@ func patchAnnotation(ctx context.Context, c client.Client, a argocdv1alpha1.Appl
 	patch.SetAnnotations(annotations)
 
 	logger.Info("apply a patch", "annotations", annotations)
-	return c.Patch(ctx, &patch, client.Apply, &client.PatchOptions{FieldManager: "argocd-commenter"})
+
+	// force applying to resolve conflicts that happen when argocd-notifications also updates the Application
+	force := true
+	patchOptions := &client.PatchOptions{FieldManager: "argocd-commenter", Force: &force}
+	return c.Patch(ctx, &patch, client.Apply, patchOptions)
 }


### PR DESCRIPTION
We're using `argocd-commenter` next to native ArgoCD notifications (slack & grafana). 

We noticed that after some time the comments of the commenter regarding health-status stopped working. The following log message explains the root issue - the commenter can no longer apply it's last synced revision annotation:
```
argocd-commenter-controller-manager-5b8c598fd9-72w7f manager 1.6612763370444894e+09     INFO    controller.application  apply a patch   {"reconciler group": "argoproj.io", "recon
ciler kind": "Application", "name": "app-1234", "namespace": "argocd", "annotations": {"argocd-commenter.int128.github.io/last-revision-healthy":"235f6823c4f053090b45038aa71
6f077a856463b", ...}
argocd-commenter-controller-manager-5b8c598fd9-72w7f manager 1.661276337054249e+09      ERROR   controller.application  unable to patch annotations to the Application  {"reconcil
er group": "argoproj.io", "reconciler kind": "Application", "name": "app-1234", "namespace": "argocd", "error": "Apply failed with 1 conflict: conflict with \"argocd-notific
ations\" using argoproj.io/v1alpha1: .metadata.annotations.argocd-commenter.int128.github.io/last-revision-healthy"}
```

The problem is that `argocd-notifications` also persists some state on the Applications' annotation and since they employ [a custom merge mechanism](https://github.com/argoproj/notifications-engine/blob/master/pkg/controller/controller.go#L235-L261), it claims ownership of `argocd-commenter.int128.github.io/last-revision-healthy`, as can be seen in the `managedFields`:

```
  managedFields:
    - apiVersion: argoproj.io/v1alpha1
      fieldsType: FieldsV1
      fieldsV1:
        'f:metadata':
          'f:annotations':
            'f:argocd.argoproj.io/manifest-generate-paths': {}
            'f:notifications.argoproj.io/subscribe.on-deployed.grafana': {}
      manager: argocd-commenter
      operation: Apply
      time: '2022-08-22T15:21:08Z'
    - apiVersion: argoproj.io/v1alpha1
      fieldsType: FieldsV1
      fieldsV1:
        'f:metadata':
          'f:annotations':
            'f:argocd-commenter.int128.github.io/last-revision-healthy': {}
            'f:notified.notifications.argoproj.io': {}
      manager: argocd-notifications
      operation: Update
      time: '2022-08-22T15:21:09Z'
```

The only way to resolve that conflict is to add `Force: true` to the patch options for the commenter. 

I'm not sure this is the clean approach, but it solved the issue on our cluster. Both commenter as well as native notification work parallely.

