### PR TITLE
Add test of no-progressing resource

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -125,6 +125,16 @@ jobs:
           DEPLOYMENT_URL: ${{ steps.deployment-app2.outputs.url }}
           GITHUB_TOKEN: ${{ steps.octoken.outputs.token }}
 
+      - uses: int128/deployment-action@v1
+        id: deployment-app3
+        with:
+          environment-suffix: /app3
+      - run: make -C e2e_test deploy-app3
+        env:
+          PULL_REQUEST_BODY: "e2e-test ${{ github.repository }}#${{ github.event.pull_request.number }}"
+          DEPLOYMENT_URL: ${{ steps.deployment-app2.outputs.url }}
+          GITHUB_TOKEN: ${{ steps.octoken.outputs.token }}
+
       # show logs
       - run: make -C e2e_test logs-argocd
         if: always()

--- a/e2e_test/Makefile
+++ b/e2e_test/Makefile
@@ -35,6 +35,7 @@ wait-for-ready:
 	kubectl -n argocd rollout status statefulsets argocd-application-controller
 	./wait-for-sync-status.sh app1 $(FIXTURE_BRANCH)/main Synced Succeeded Healthy
 	./wait-for-sync-status.sh app2 $(FIXTURE_BRANCH)/main Synced Succeeded Healthy
+	./wait-for-sync-status.sh app3 $(FIXTURE_BRANCH)/main Synced Succeeded Healthy
 	kubectl -n argocd-commenter-system rollout status deployment argocd-commenter-controller-manager
 
 undeploy:
@@ -55,6 +56,11 @@ deploy-app2:
 	kubectl -n argocd annotate application app2 'argocd-commenter.int128.github.io/deployment-url=$(DEPLOYMENT_URL)'
 	$(MAKE) -C argocd-commenter-e2e-test-repository update-manifest-app2
 	./wait-for-sync-status.sh app2 $(FIXTURE_BRANCH)/main OutOfSync Failed Healthy
+
+deploy-app3:
+	kubectl -n argocd annotate application app3 'argocd-commenter.int128.github.io/deployment-url=$(DEPLOYMENT_URL)'
+	$(MAKE) -C argocd-commenter-e2e-test-repository update-manifest-app3
+	./wait-for-sync-status.sh app3 $(FIXTURE_BRANCH)/main Synced Succeeded Healthy
 
 logs-controller:
 	-kubectl -n argocd-commenter-system logs -l control-plane=controller-manager --all-containers --tail=-1

--- a/e2e_test/applications/app3.yaml
+++ b/e2e_test/applications/app3.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: app3
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/int128/argocd-commenter-e2e-test
+    targetRevision: FIXTURE_BRANCH/main
+    path: app3
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: test3-fixture
+  syncPolicy:
+    automated:
+      prune: true
+    retry:
+      limit: 1  # reduce test time

--- a/e2e_test/applications/kustomization.yaml
+++ b/e2e_test/applications/kustomization.yaml
@@ -1,3 +1,4 @@
 resources:
   - app1.yaml
   - app2.yaml
+  - app3.yaml

--- a/e2e_test/fixture/Makefile
+++ b/e2e_test/fixture/Makefile
@@ -29,3 +29,14 @@ update-manifest-app2:
 	gh pr merge --squash
 	git checkout "$(FIXTURE_BRANCH)/main"
 	git pull origin "$(FIXTURE_BRANCH)/main" --ff-only
+
+update-manifest-app3:
+	git checkout "$(FIXTURE_BRANCH)/main"
+	git checkout -b "$(FIXTURE_BRANCH)/update-manifest-app3"
+	sed -i -e 's/app: echoserver/app: echoserver-test3/g' app3/cronjob/echoserver.yaml
+	git commit -a -m 'e2e-test: update-manifest-app3'
+	git push origin -f "$(FIXTURE_BRANCH)/update-manifest-app3"
+	gh pr create --base "$(FIXTURE_BRANCH)/main" --fill --body "$(PULL_REQUEST_BODY)" --label e2e-test
+	gh pr merge --squash
+	git checkout "$(FIXTURE_BRANCH)/main"
+	git pull origin "$(FIXTURE_BRANCH)/main" --ff-only

--- a/e2e_test/fixture/app3/cronjob/echoserver.yaml
+++ b/e2e_test/fixture/app3/cronjob/echoserver.yaml
@@ -1,0 +1,21 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: echoserver
+spec:
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: echoserver
+        spec:
+          restartPolicy: Never
+          containers:
+            - image: busybox:1.28
+              name: echoserver
+              command:
+                - /bin/sh
+                - -c
+                - date; echo Hello from the Kubernetes cluster

--- a/e2e_test/fixture/app3/kustomization.yaml
+++ b/e2e_test/fixture/app3/kustomization.yaml
@@ -1,0 +1,4 @@
+namespace: app3
+resources:
+  - namespace/app3.yaml
+  - cronjob/echoserver.yaml

--- a/e2e_test/fixture/app3/namespace/app3.yaml
+++ b/e2e_test/fixture/app3/namespace/app3.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: app3


### PR DESCRIPTION
This adds a test case for a resource which does not trigger "progressing" state, such as `CronJob`.

Currently, the deployment is not changed to "Active" state.

<img width="860" alt="image" src="https://user-images.githubusercontent.com/321266/191232072-e7c2287a-ed6a-4016-8f83-44b6a13203ea.png">
