### PR TITLE
Fix deployment did not become Active for CronJob

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -136,6 +136,7 @@ jobs:
           PULL_REQUEST_BODY: "e2e-test ${{ github.repository }}#${{ github.event.pull_request.number }}"
           DEPLOYMENT_URL: ${{ steps.deployment-app3.outputs.url }}
           GITHUB_TOKEN: ${{ steps.octoken.outputs.token }}
+      - run: sleep 3 # wait for deployment status
 
       - run: make -C e2e_test delete-apps
 

--- a/pkg/notification/deployment.go
+++ b/pkg/notification/deployment.go
@@ -58,6 +58,12 @@ func generateDeploymentStatus(e Event) *github.DeploymentStatus {
 			ds.State = "queued"
 			return &ds
 		case synccommon.OperationSucceeded:
+			// Some resources (such as CronJob) do not trigger Progressing status.
+			// If healthy, complete the deployment as success.
+			if e.Application.Status.Health.Status == health.HealthStatusHealthy {
+				ds.State = "success"
+				return &ds
+			}
 			ds.State = "in_progress"
 			return &ds
 		case synccommon.OperationFailed:


### PR DESCRIPTION
## Problem to solve
Some resources (such as CronJob or ConfigMap) do not trigger Progressing status. Consequently, the deployment is still in-progress after deploy.

## How to solve
When an application is successfully synced and healthy, it changes the deployment to success.

It seems no problem to determine if an application is healthy when sync phase is changed, because the health status is updated in the sync operation.
https://github.com/argoproj/gitops-engine/blob/v0.7.3/pkg/sync/sync_context.go#L407-L438
