### PR TITLE
Keep final deployment status in E2E test

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -138,9 +138,6 @@ jobs:
           PULL_REQUEST_BODY: "e2e-test ${{ github.repository }}#${{ github.event.pull_request.number }}"
           DEPLOYMENT_URL: ${{ steps.deployment-app3.outputs.url }}
           GITHUB_TOKEN: ${{ steps.octoken.outputs.token }}
-      - run: sleep 3 # wait for deployment status
-
-      - run: make -C e2e_test delete-apps
 
       # show logs
       - run: make -C e2e_test logs-argocd

--- a/e2e_test/Makefile
+++ b/e2e_test/Makefile
@@ -55,9 +55,6 @@ deploy-app3:
 	$(MAKE) -C $(FIXTURE_DIR) update-manifest-app3
 	go run ./waitforapp -revision "`git -C $(FIXTURE_DIR) rev-parse $(FIXTURE_BASE_BRANCH)`" app3
 
-delete-apps:
-	kubectl -n argocd delete applications -l int128.github.io/e2e-test=fixture
-
 logs-controller:
 	-kubectl -n argocd-commenter-system logs -l control-plane=controller-manager --all-containers --tail=-1
 logs-argocd:


### PR DESCRIPTION
## Problem to solve
Currently the deployment statuses become "Destroyed" after the E2E test.
It would be nice if we can see the final status.
