### PR TITLE
Revert #727: Fix deployment did not become Active for CronJob

### DIFF
--- a/pkg/notification/deployment.go
+++ b/pkg/notification/deployment.go
@@ -50,12 +50,6 @@ func generateDeploymentStatusOnPhaseChanged(app argocdv1alpha1.Application, argo
 		ds.State = "queued"
 		return &ds
 	case synccommon.OperationSucceeded:
-		// Some resources (such as CronJob) do not trigger Progressing status.
-		// If healthy, complete the deployment as success.
-		if app.Status.Health.Status == health.HealthStatusHealthy {
-			ds.State = "success"
-			return &ds
-		}
 		ds.State = "in_progress"
 		return &ds
 	case synccommon.OperationFailed:


### PR DESCRIPTION
## Problem to solve
It eventually notifies a deployment status of success before an application is progressing.

1. Application phase is running
2. Application phase is succeeded and application is healthy
3. Application is progressing
4. Application is healthy

Step 2 and 3 are triggered in very short time.

## How to solve
Revert https://github.com/int128/argocd-commenter/pull/727.

## Caveat
If an application has only non-workload resource (such as ConfigMap or CronJob), it does not notify a deployment status of success.

<img width="670" alt="image" src="https://user-images.githubusercontent.com/321266/198033596-d3c52ce4-e99b-4e4c-919b-e68db38652d4.png">
