### PR TITLE
Check the current deployment status from GitHub API

### DIFF
--- a/api/v1/applicationhealth_types.go
+++ b/api/v1/applicationhealth_types.go
@@ -32,10 +32,6 @@ type ApplicationHealthStatus struct {
 	// Last revision when the application is healthy.
 	// +optional
 	LastHealthyRevision string `json:"lastHealthyRevision,omitempty"`
-
-	// Last deployment URL when the application is healthy.
-	// +optional
-	LastHealthyDeploymentURL string `json:"lastHealthyDeploymentURL,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/argocdcommenter.int128.github.io_applicationhealths.yaml
+++ b/config/crd/bases/argocdcommenter.int128.github.io_applicationhealths.yaml
@@ -38,9 +38,6 @@ spec:
           status:
             description: ApplicationHealthStatus defines the observed state of ApplicationHealth
             properties:
-              lastHealthyDeploymentURL:
-                description: Last deployment URL when the application is healthy.
-                type: string
               lastHealthyRevision:
                 description: Last revision when the application is healthy.
                 type: string

--- a/controllers/applicationphasedeployment_controller_test.go
+++ b/controllers/applicationphasedeployment_controller_test.go
@@ -6,6 +6,7 @@ import (
 	argocdv1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/gitops-engine/pkg/health"
 	synccommon "github.com/argoproj/gitops-engine/pkg/sync/common"
+	"github.com/google/go-github/v47/github"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,6 +47,8 @@ var _ = Describe("Application phase controller", func() {
 
 	Context("When an application is synced", func() {
 		It("Should notify a deployment status", func() {
+			githubMock.DeploymentStatuses.SetResponse(999100, []*github.DeploymentStatus{})
+
 			By("By updating the operation state to running")
 			patch := client.MergeFrom(app.DeepCopy())
 			app.Annotations = map[string]string{
@@ -81,6 +84,8 @@ var _ = Describe("Application phase controller", func() {
 
 	Context("When an application sync operation is failed", func() {
 		It("Should notify a deployment status", func() {
+			githubMock.DeploymentStatuses.SetResponse(999101, []*github.DeploymentStatus{})
+
 			By("By updating the operation state to running")
 			patch := client.MergeFrom(app.DeepCopy())
 			app.Annotations = map[string]string{
@@ -116,6 +121,8 @@ var _ = Describe("Application phase controller", func() {
 
 	Context("When an application is re-synced", func() {
 		It("Should skip the notification", func() {
+			githubMock.DeploymentStatuses.SetResponse(999102, []*github.DeploymentStatus{})
+
 			By("By updating the operation state to succeeded")
 			app.Annotations = map[string]string{
 				"argocd-commenter.int128.github.io/deployment-url": "https://api.github.com/repos/int128/manifests/deployments/999102",

--- a/controllers/mocks_test.go
+++ b/controllers/mocks_test.go
@@ -13,21 +13,21 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-type Recorder[K int | string] struct {
-	m       sync.Mutex
-	counter map[K]int
+type Endpoint[K int | string, V interface{}] struct {
+	m        sync.Mutex
+	counter  map[K]int
+	response map[K]V
 }
 
-func (r *Recorder[K]) CountBy(key K) int {
+func (r *Endpoint[K, V]) CountBy(key K) int {
 	r.m.Lock()
 	defer r.m.Unlock()
 	return r.counter[key]
 }
 
-func (r *Recorder[K]) call(key K) int {
+func (r *Endpoint[K, V]) call(key K) int {
 	r.m.Lock()
 	defer r.m.Unlock()
-
 	if r.counter == nil {
 		r.counter = make(map[K]int)
 	}
@@ -35,9 +35,24 @@ func (r *Recorder[K]) call(key K) int {
 	return r.counter[key]
 }
 
+func (r *Endpoint[K, V]) getResponse(k K) V {
+	r.m.Lock()
+	defer r.m.Unlock()
+	return r.response[k]
+}
+
+func (r *Endpoint[K, V]) SetResponse(k K, v V) {
+	r.m.Lock()
+	defer r.m.Unlock()
+	if r.response == nil {
+		r.response = make(map[K]V)
+	}
+	r.response[k] = v
+}
+
 type GithubMock struct {
-	Comments           Recorder[int]
-	DeploymentStatuses Recorder[int]
+	Comments           Endpoint[int, any]
+	DeploymentStatuses Endpoint[int, []*github.DeploymentStatus]
 }
 
 func (m *GithubMock) NewHandler() http.Handler {
@@ -45,13 +60,16 @@ func (m *GithubMock) NewHandler() http.Handler {
 		"GET /api/v3/repos/int128/manifests/commits/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa100/pulls": m.listPullRequestsWithCommit(100),
 		"GET /api/v3/repos/int128/manifests/pulls/100/files":                                        m.listFiles(),
 		"POST /api/v3/repos/int128/manifests/issues/100/comments":                                   m.createComment(100),
+		"GET /api/v3/repos/int128/manifests/deployments/999100/statuses":                            m.listDeploymentStatus(999100),
 		"POST /api/v3/repos/int128/manifests/deployments/999100/statuses":                           m.createDeploymentStatus(999100),
 
 		"GET /api/v3/repos/int128/manifests/commits/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa101/pulls": m.listPullRequestsWithCommit(101),
 		"GET /api/v3/repos/int128/manifests/pulls/101/files":                                        m.listFiles(),
 		"POST /api/v3/repos/int128/manifests/issues/101/comments":                                   m.createComment(101),
+		"GET /api/v3/repos/int128/manifests/deployments/999101/statuses":                            m.listDeploymentStatus(999101),
 		"POST /api/v3/repos/int128/manifests/deployments/999101/statuses":                           m.createDeploymentStatus(999101),
 
+		"GET /api/v3/repos/int128/manifests/deployments/999102/statuses":  m.listDeploymentStatus(999102),
 		"POST /api/v3/repos/int128/manifests/deployments/999102/statuses": m.createDeploymentStatus(999102),
 
 		"GET /api/v3/repos/int128/manifests/commits/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa200/pulls": m.listPullRequestsWithCommit(200),
@@ -63,9 +81,13 @@ func (m *GithubMock) NewHandler() http.Handler {
 		"POST /api/v3/repos/int128/manifests/issues/201/comments":                                   m.createComment(201),
 
 		"GET /api/v3/repos/int128/manifests/commits/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/pulls": http.NotFound,
+		"GET /api/v3/repos/int128/manifests/deployments/999999/statuses":                            http.NotFound,
 		"POST /api/v3/repos/int128/manifests/deployments/999999/statuses":                           http.NotFound,
+		"GET /api/v3/repos/int128/manifests/deployments/999300/statuses":                            m.listDeploymentStatus(999300),
 		"POST /api/v3/repos/int128/manifests/deployments/999300/statuses":                           m.createDeploymentStatus(999300),
+		"GET /api/v3/repos/int128/manifests/deployments/999301/statuses":                            m.listDeploymentStatus(999301),
 		"POST /api/v3/repos/int128/manifests/deployments/999301/statuses":                           m.createDeploymentStatus(999301),
+		"GET /api/v3/repos/int128/manifests/deployments/999302/statuses":                            m.listDeploymentStatus(999302),
 		"POST /api/v3/repos/int128/manifests/deployments/999302/statuses":                           m.createDeploymentStatus(999302),
 	}
 
@@ -111,8 +133,22 @@ func (m *GithubMock) createDeploymentStatus(id int) http.HandlerFunc {
 		w.Header().Add("content-type", "application/json")
 		w.WriteHeader(200)
 		m.DeploymentStatuses.call(id)
-		b, err := io.ReadAll(r.Body)
-		Expect(err).Should(Succeed())
-		GinkgoWriter.Println("GITHUB", "created deployment status", strings.TrimSpace(string(b)))
+		var ds github.DeploymentStatusRequest
+		Expect(json.NewDecoder(r.Body).Decode(&ds)).Should(Succeed())
+		GinkgoWriter.Println("GITHUB", "created deployment status", ds)
+		m.DeploymentStatuses.SetResponse(id, []*github.DeploymentStatus{{State: ds.State}})
+	}
+}
+
+func (m *GithubMock) listDeploymentStatus(id int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ds := m.DeploymentStatuses.getResponse(id)
+		if ds == nil {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Add("content-type", "application/json")
+		w.WriteHeader(200)
+		Expect(json.NewEncoder(w).Encode(ds)).Should(Succeed())
 	}
 }

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"testing"
+	"time"
 
 	argocdv1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/int128/argocd-commenter/pkg/github"
@@ -148,6 +149,8 @@ var _ = BeforeSuite(func() {
 		Notification: nc,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
+
+	requeueIntervalWhenDeploymentNotFound = 1 * time.Second
 
 	go func() {
 		defer GinkgoRecover()

--- a/pkg/github/deployment.go
+++ b/pkg/github/deployment.go
@@ -57,3 +57,20 @@ func (c *client) CreateDeploymentStatus(ctx context.Context, d Deployment, ds De
 	}
 	return nil
 }
+
+func (c *client) FindLatestDeploymentStatus(ctx context.Context, d Deployment) (*DeploymentStatus, error) {
+	r, _, err := c.rest.Repositories.ListDeploymentStatuses(ctx, d.Repository.Owner, d.Repository.Name, d.Id, nil)
+	if err != nil {
+		return nil, fmt.Errorf("GitHub API error: %w", err)
+	}
+	if len(r) == 0 {
+		return nil, nil
+	}
+	ds := r[0]
+	return &DeploymentStatus{
+		State:          ds.GetState(),
+		Description:    ds.GetDescription(),
+		LogURL:         ds.GetLogURL(),
+		EnvironmentURL: ds.GetEnvironmentURL(),
+	}, nil
+}

--- a/pkg/github/types.go
+++ b/pkg/github/types.go
@@ -12,6 +12,7 @@ type Client interface {
 	ListPullRequests(ctx context.Context, r Repository, revision string) ([]PullRequest, error)
 	CreateComment(ctx context.Context, r Repository, pullNumber int, body string) error
 	CreateDeploymentStatus(ctx context.Context, d Deployment, ds DeploymentStatus) error
+	FindLatestDeploymentStatus(ctx context.Context, d Deployment) (*DeploymentStatus, error)
 }
 
 type Repository struct {

--- a/pkg/notification/deployment.go
+++ b/pkg/notification/deployment.go
@@ -136,3 +136,18 @@ func (c client) CreateDeployment(ctx context.Context, ds DeploymentStatus) error
 	logger.Info("created a deployment status")
 	return nil
 }
+
+func (c client) CheckIfDeploymentIsAlreadyHealthy(ctx context.Context, deploymentURL string) (bool, error) {
+	deployment := github.ParseDeploymentURL(deploymentURL)
+	if deployment == nil {
+		return false, nil
+	}
+	latestDeploymentStatus, err := c.ghc.FindLatestDeploymentStatus(ctx, *deployment)
+	if err != nil {
+		return false, fmt.Errorf("unable to find the latest deployment status: %w", err)
+	}
+	if latestDeploymentStatus == nil {
+		return false, nil
+	}
+	return latestDeploymentStatus.State == "success", nil
+}

--- a/pkg/notification/types.go
+++ b/pkg/notification/types.go
@@ -10,6 +10,7 @@ import (
 type Client interface {
 	CreateComment(ctx context.Context, comment Comment, app argocdv1alpha1.Application) error
 	CreateDeployment(ctx context.Context, ds DeploymentStatus) error
+	CheckIfDeploymentIsAlreadyHealthy(ctx context.Context, deploymentURL string) (bool, error)
 }
 
 func NewClient(ghc github.Client) Client {


### PR DESCRIPTION
This fixes the edge case of https://github.com/int128/argocd-commenter/issues/762#issuecomment-1304465447.

It removes `lastHealthyDeploymentURL` field. Instead, it checks the current deployment status from GitHub API.
