### PR TITLE
Enable HTTP cache for GitHub API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-github/v47 v47.1.0
+	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
 	github.com/int128/oauth2-github-app v1.0.0
 	github.com/onsi/ginkgo/v2 v2.4.0
 	github.com/onsi/gomega v1.24.0
@@ -75,7 +76,6 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
-	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/google/go-github/v47/github"
+	"github.com/gregjones/httpcache"
 	"github.com/int128/oauth2-github-app"
 	"golang.org/x/oauth2"
 )
@@ -16,6 +17,8 @@ type client struct {
 }
 
 func NewClient(ctx context.Context) (Client, error) {
+	transport := httpcache.NewMemoryCacheTransport()
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, transport)
 	oauth2Client, err := newOAuth2Client(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("could not create an OAuth2 client: %w", err)


### PR DESCRIPTION
Follow up #801. This will mitigate the rate limit of GitHub API.
