### PR TITLE
Set retry timeout on deployment not found error

### DIFF
--- a/controllers/applicationphasedeployment_controller.go
+++ b/controllers/applicationphasedeployment_controller.go
@@ -71,14 +71,16 @@ func (r *ApplicationPhaseDeploymentReconciler) Reconcile(ctx context.Context, re
 		// Retry until the application is synced with a valid GitHub Deployment.
 		// https://github.com/int128/argocd-commenter/issues/762
 		lastOperationAt := argocd.GetLastOperationAt(app)
-		if time.Now().After(lastOperationAt.Add(requeueTimeoutWhenDeploymentNotFound)) {
-			logger.Info("requeue timeout because last operation is too old", "lastOperationAt", lastOperationAt)
-			return ctrl.Result{}, nil
+		if time.Now().Before(lastOperationAt.Add(requeueTimeoutWhenDeploymentNotFound)) {
+			logger.Info("retry due to deployment not found error", "after", requeueIntervalWhenDeploymentNotFound, "error", err)
+			r.Recorder.Eventf(&app, corev1.EventTypeNormal, "DeploymentNotFound",
+				"deployment %s not found, retry after %s", deploymentURL, requeueIntervalWhenDeploymentNotFound)
+			return ctrl.Result{RequeueAfter: requeueIntervalWhenDeploymentNotFound}, nil
 		}
-		logger.Info("requeue because deployment is not found", "after", requeueIntervalWhenDeploymentNotFound, "error", err)
-		r.Recorder.Eventf(&app, corev1.EventTypeNormal, "DeploymentNotFound",
-			"deployment %s is not found, requeue after %s", deploymentURL, requeueIntervalWhenDeploymentNotFound)
-		return ctrl.Result{RequeueAfter: requeueIntervalWhenDeploymentNotFound}, nil
+		logger.Info("retry timeout because last operation is too old", "lastOperationAt", lastOperationAt)
+		r.Recorder.Eventf(&app, corev1.EventTypeWarning, "DeploymentNotFoundRetryTimeout",
+			"deployment %s not found, retry timeout", deploymentURL)
+		return ctrl.Result{}, nil
 	}
 	if deploymentIsAlreadyHealthy {
 		logger.Info("skip notification because the deployment is already healthy", "deployment", deploymentURL)

--- a/pkg/argocd/application.go
+++ b/pkg/argocd/application.go
@@ -37,8 +37,8 @@ func GetLastOperationAt(a argocdv1alpha1.Application) metav1.Time {
 	if a.Status.OperationState == nil {
 		return metav1.Time{}
 	}
-	if a.Status.OperationState.FinishedAt == nil {
-		return a.Status.OperationState.StartedAt
+	if a.Status.OperationState.FinishedAt != nil {
+		return *a.Status.OperationState.FinishedAt
 	}
-	return *a.Status.OperationState.FinishedAt
+	return a.Status.OperationState.StartedAt
 }

--- a/pkg/argocd/application.go
+++ b/pkg/argocd/application.go
@@ -3,6 +3,7 @@ package argocd
 import (
 	argocdv1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	synccommon "github.com/argoproj/gitops-engine/pkg/sync/common"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // GetDeployedRevision returns the last synced revision
@@ -29,4 +30,15 @@ func GetOperationPhase(a argocdv1alpha1.Application) synccommon.OperationPhase {
 		return ""
 	}
 	return a.Status.OperationState.Phase
+}
+
+// GetLastOperationAt returns OperationState.FinishedAt, OperationState.StartedAt or zero Time.
+func GetLastOperationAt(a argocdv1alpha1.Application) metav1.Time {
+	if a.Status.OperationState == nil {
+		return metav1.Time{}
+	}
+	if a.Status.OperationState.FinishedAt == nil {
+		return a.Status.OperationState.StartedAt
+	}
+	return *a.Status.OperationState.FinishedAt
 }


### PR DESCRIPTION
## Problem to solve
When an invalid GitHub Deployment is set in an Application, this controller will retry the notification forever. It may cause the rate limit of GitHub API.

## How to solve
Set a timeout.