### PR TITLE
Extend timeout of docker build

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -41,7 +41,7 @@ jobs:
           - linux/amd64
           - linux/arm64
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: docker/login-action@v2
         with:


### PR DESCRIPTION
Follow up https://github.com/int128/argocd-commenter/pull/813.