### PR TITLE
Revert "Enable gomodMassage in Renovate"

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,11 +3,6 @@
     "github>int128/renovate-base",
     "github>int128/go-actions",
   ],
-  "postUpdateOptions": [
-    // update replace statements in go.mod
-    // https://docs.renovatebot.com/golang/#replace-massaging
-    "gomodMassage",
-  ],
   "regexManagers": [
     {
       "fileMatch": [


### PR DESCRIPTION
Reverts int128/argocd-commenter#829.

It did not work.
https://github.com/int128/argocd-commenter/pull/793#issuecomment-1369441772

```
Command failed: docker run --rm --name=renovate_sidecar --label=renovate_child -v "/mnt/renovate/gh/int128/argocd-commenter":"/mnt/renovate/gh/int128/argocd-commenter" -v "/tmp/renovate-cache":"/tmp/renovate-cache" -v "/tmp/containerbase":"/tmp/containerbase" -e GOPATH -e GOPROXY -e GOFLAGS -e CGO_ENABLED -e GIT_CONFIG_KEY_0 -e GIT_CONFIG_VALUE_0 -e GIT_CONFIG_KEY_1 -e GIT_CONFIG_VALUE_1 -e GIT_CONFIG_KEY_2 -e GIT_CONFIG_VALUE_2 -e GIT_CONFIG_COUNT -e BUILDPACK_CACHE_DIR -e CONTAINERBASE_CACHE_DIR -w "/mnt/renovate/gh/int128/argocd-commenter" docker.io/renovate/sidecar bash -l -c "install-tool golang 1.19.4 && go get -d -t ./... && go mod tidy && go mod tidy"
go: k8s.io/kubernetes@v1.23.1 requires
	k8s.io/api@v0.0.0: reading k8s.io/api/go.mod at revision v0.0.0: unknown revision v0.0.0
```