### PR TITLE
Remove toolchain from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/int128/argocd-commenter
 
 go 1.21
 
-toolchain go1.21.0
-
 require (
 	github.com/argoproj/argo-cd/v2 v2.9.0
 	github.com/argoproj/gitops-engine v0.7.1-0.20230906152414-b0fffe419a0f


### PR DESCRIPTION
Renovate was stuck in https://github.com/int128/argocd-commenter/pull/979#issuecomment-1758788982

```
could not get go.mod file: could not parse go.mod file: go.mod:5: unknown directive: toolchain
```