### PR TITLE
Add full support for Argo CD external urls

### DIFF
--- a/internal/notification/healthdeployment.go
+++ b/internal/notification/healthdeployment.go
@@ -42,7 +42,16 @@ func generateDeploymentStatusOnHealthChanged(app argocdv1alpha1.Application, arg
 		},
 	}
 	if len(app.Status.Summary.ExternalURLs) > 0 {
-		ds.GitHubDeploymentStatus.EnvironmentURL = app.Status.Summary.ExternalURLs[0]
+		// Split the first element of ExternalURLs by `|`
+		parts := strings.SplitN(app.Status.Summary.ExternalURLs[0], "|", 2)
+		if len(parts) == 2 {
+			// Assign the second part to EnvironmentURL as url
+			// https://argo-cd.readthedocs.io/en/stable/user-guide/external-url/
+			// this is hidden supported functionality https://github.com/argoproj/argo-cd/blob/f0b03071fc00fd81433d2c16861c193992d5a093/common/common.go#L186
+			ds.GitHubDeploymentStatus.EnvironmentURL = parts[1]
+		} else {
+			ds.GitHubDeploymentStatus.EnvironmentURL = app.Status.Summary.ExternalURLs[0]
+		}
 	}
 	switch app.Status.Health.Status {
 	case health.HealthStatusHealthy:

--- a/internal/notification/phasedeployment.go
+++ b/internal/notification/phasedeployment.go
@@ -49,7 +49,16 @@ func generateDeploymentStatusOnPhaseChanged(app argocdv1alpha1.Application, argo
 		},
 	}
 	if len(app.Status.Summary.ExternalURLs) > 0 {
-		ds.GitHubDeploymentStatus.EnvironmentURL = app.Status.Summary.ExternalURLs[0]
+		// Split the first element of ExternalURLs by `|`
+		parts := strings.SplitN(app.Status.Summary.ExternalURLs[0], "|", 2)
+		if len(parts) == 2 {
+			// Assign the second part to EnvironmentURL as url
+			// https://argo-cd.readthedocs.io/en/stable/user-guide/external-url/
+			// this is hidden supported functionality https://github.com/argoproj/argo-cd/blob/f0b03071fc00fd81433d2c16861c193992d5a093/common/common.go#L186
+			ds.GitHubDeploymentStatus.EnvironmentURL = parts[1]
+		} else {
+			ds.GitHubDeploymentStatus.EnvironmentURL = app.Status.Summary.ExternalURLs[0]
+		}
 	}
 	switch phase {
 	case synccommon.OperationRunning:


### PR DESCRIPTION
Enables full support for External URL's in Argo CD. 
Otherwise it will throw error during updating deployment status.

I'm not go developer(but java), please check if it ok from go perspective.
I'm providing my verbal approve to edit this PR by maintainers in order to merge it as fast as possible.
Thanks!