### PR TITLE
feat: add source repository filtering for PR comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,29 @@ metadata:
     argocd-commenter.int128.github.io/deployment-url: https://api.github.com/repos/OWNER/REPO/deployments/ID
 ```
 
+## Source repository filtering
+
+When an Application uses multi-source, you can control which source repositories receive PR and commit comments using these annotations:
+
+| Annotation | Description |
+|---|---|
+| `argocd-commenter.int128.github.io/include-repo-urls` | Semicolon-separated list of source repo URLs. If set, only these repos receive PR comments. Takes priority over exclude. |
+| `argocd-commenter.int128.github.io/exclude-repo-urls` | Semicolon-separated list of source repo URLs to exclude from PR comments. Ignored if include is set. |
+
+URLs are compared as exact strings after trimming any trailing `.git` suffix from both sides.
+
+This is useful when a `ref:`-only source (e.g., for shared Helm values) has no `path`, causing the commenter to match every file in every PR of that repository.
+
+Example — exclude a shared values repo:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    argocd-commenter.int128.github.io/exclude-repo-urls: "https://github.com/owner/helm-values"
+```
+
 Here is an example of workflow to deploy a preview environment:
 
 ```yaml

--- a/internal/argocd/application.go
+++ b/internal/argocd/application.go
@@ -1,12 +1,61 @@
 package argocd
 
 import (
+	"slices"
 	"strings"
 
 	argocdv1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	synccommon "github.com/argoproj/gitops-engine/pkg/sync/common"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+const (
+	AnnotationIncludeRepoURLs = "argocd-commenter.int128.github.io/include-repo-urls"
+	AnnotationExcludeRepoURLs = "argocd-commenter.int128.github.io/exclude-repo-urls"
+)
+
+type RepoURLFilter struct {
+	includeURLs []string
+	excludeURLs []string
+}
+
+// NewRepoURLFilter creates a filter from Application annotations.
+// If include-repo-urls is set, exclude-repo-urls is ignored.
+func NewRepoURLFilter(app argocdv1alpha1.Application) RepoURLFilter {
+	if app.Annotations == nil {
+		return RepoURLFilter{}
+	}
+	if include, ok := app.Annotations[AnnotationIncludeRepoURLs]; ok && include != "" {
+		return RepoURLFilter{includeURLs: parseRepoURLList(include)}
+	}
+	if exclude, ok := app.Annotations[AnnotationExcludeRepoURLs]; ok && exclude != "" {
+		return RepoURLFilter{excludeURLs: parseRepoURLList(exclude)}
+	}
+	return RepoURLFilter{}
+}
+
+func (f RepoURLFilter) Allows(repoURL string) bool {
+	normalized := strings.TrimSuffix(repoURL, ".git")
+	if f.includeURLs != nil {
+		return slices.Contains(f.includeURLs, normalized)
+	}
+	if f.excludeURLs != nil {
+		return !slices.Contains(f.excludeURLs, normalized)
+	}
+	return true
+}
+
+func parseRepoURLList(s string) []string {
+	parts := strings.Split(s, ";")
+	urls := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			urls = append(urls, strings.TrimSuffix(p, ".git"))
+		}
+	}
+	return urls
+}
 
 type SourceRevision struct {
 	Source   argocdv1alpha1.ApplicationSource

--- a/internal/argocd/application_test.go
+++ b/internal/argocd/application_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	argocdv1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGetApplicationExternalURL(t *testing.T) {
@@ -50,6 +51,157 @@ func TestGetApplicationExternalURL(t *testing.T) {
 		externalURL := GetApplicationExternalURL(app)
 		if want := "https://example.com/argocd"; externalURL != want {
 			t.Errorf("externalURL wants %s but got %s", want, externalURL)
+		}
+	})
+}
+
+func TestRepoURLFilter(t *testing.T) {
+	t.Run("neither annotation set allows all", func(t *testing.T) {
+		app := argocdv1alpha1.Application{}
+		f := NewRepoURLFilter(app)
+		if !f.Allows("https://github.com/org/repo-a") {
+			t.Error("expected Allows to return true")
+		}
+	})
+
+	t.Run("nil annotations allows all", func(t *testing.T) {
+		app := argocdv1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{Annotations: nil},
+		}
+		f := NewRepoURLFilter(app)
+		if !f.Allows("https://github.com/org/anything") {
+			t.Error("expected Allows to return true")
+		}
+	})
+
+	t.Run("include only allows listed URLs", func(t *testing.T) {
+		app := argocdv1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					AnnotationIncludeRepoURLs: "https://github.com/org/repo-a",
+				},
+			},
+		}
+		f := NewRepoURLFilter(app)
+		if !f.Allows("https://github.com/org/repo-a") {
+			t.Error("expected repo-a to be allowed")
+		}
+		if f.Allows("https://github.com/org/repo-b") {
+			t.Error("expected repo-b to be denied")
+		}
+	})
+
+	t.Run("exclude blocks listed URLs", func(t *testing.T) {
+		app := argocdv1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					AnnotationExcludeRepoURLs: "https://github.com/org/repo-a",
+				},
+			},
+		}
+		f := NewRepoURLFilter(app)
+		if f.Allows("https://github.com/org/repo-a") {
+			t.Error("expected repo-a to be denied")
+		}
+		if !f.Allows("https://github.com/org/repo-b") {
+			t.Error("expected repo-b to be allowed")
+		}
+	})
+
+	t.Run("include takes priority over exclude", func(t *testing.T) {
+		app := argocdv1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					AnnotationIncludeRepoURLs: "https://github.com/org/repo-a",
+					AnnotationExcludeRepoURLs: "https://github.com/org/repo-a",
+				},
+			},
+		}
+		f := NewRepoURLFilter(app)
+		if !f.Allows("https://github.com/org/repo-a") {
+			t.Error("expected repo-a to be allowed (include takes priority)")
+		}
+		if f.Allows("https://github.com/org/repo-b") {
+			t.Error("expected repo-b to be denied (not in include list)")
+		}
+	})
+
+	t.Run("multiple semicolon-separated URLs", func(t *testing.T) {
+		app := argocdv1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					AnnotationIncludeRepoURLs: "https://github.com/org/repo-a;https://github.com/org/repo-b",
+				},
+			},
+		}
+		f := NewRepoURLFilter(app)
+		if !f.Allows("https://github.com/org/repo-a") {
+			t.Error("expected repo-a to be allowed")
+		}
+		if !f.Allows("https://github.com/org/repo-b") {
+			t.Error("expected repo-b to be allowed")
+		}
+		if f.Allows("https://github.com/org/repo-c") {
+			t.Error("expected repo-c to be denied")
+		}
+	})
+
+	t.Run("trailing .git in annotation matches URL without .git", func(t *testing.T) {
+		app := argocdv1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					AnnotationIncludeRepoURLs: "https://github.com/org/repo-a.git",
+				},
+			},
+		}
+		f := NewRepoURLFilter(app)
+		if !f.Allows("https://github.com/org/repo-a") {
+			t.Error("expected URL without .git to match annotation with .git")
+		}
+	})
+
+	t.Run("URL with .git matches annotation without .git", func(t *testing.T) {
+		app := argocdv1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					AnnotationIncludeRepoURLs: "https://github.com/org/repo-a",
+				},
+			},
+		}
+		f := NewRepoURLFilter(app)
+		if !f.Allows("https://github.com/org/repo-a.git") {
+			t.Error("expected URL with .git to match annotation without .git")
+		}
+	})
+
+	t.Run("empty annotation value treated as not set", func(t *testing.T) {
+		app := argocdv1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					AnnotationIncludeRepoURLs: "",
+				},
+			},
+		}
+		f := NewRepoURLFilter(app)
+		if !f.Allows("https://github.com/org/anything") {
+			t.Error("expected empty include annotation to allow all")
+		}
+	})
+
+	t.Run("whitespace around URLs is trimmed", func(t *testing.T) {
+		app := argocdv1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					AnnotationIncludeRepoURLs: " https://github.com/org/repo-a ; https://github.com/org/repo-b ",
+				},
+			},
+		}
+		f := NewRepoURLFilter(app)
+		if !f.Allows("https://github.com/org/repo-a") {
+			t.Error("expected repo-a to be allowed after trimming")
+		}
+		if !f.Allows("https://github.com/org/repo-b") {
+			t.Error("expected repo-b to be allowed after trimming")
 		}
 	})
 }

--- a/internal/notification/healthcomment.go
+++ b/internal/notification/healthcomment.go
@@ -20,7 +20,11 @@ var HealthStatusesForComment = []health.HealthStatusCode{
 func (c client) CreateCommentsOnHealthChanged(ctx context.Context, app argocdv1alpha1.Application, argocdURL string) error {
 	var errs []error
 	sourceRevisions := argocd.GetSourceRevisions(app)
+	repoFilter := argocd.NewRepoURLFilter(app)
 	for _, sourceRevision := range sourceRevisions {
+		if !repoFilter.Allows(sourceRevision.Source.RepoURL) {
+			continue
+		}
 		comment := generateCommentOnHealthChanged(app, argocdURL, sourceRevision)
 		if comment == nil {
 			continue

--- a/internal/notification/healthcomment_test.go
+++ b/internal/notification/healthcomment_test.go
@@ -1,0 +1,63 @@
+package notification
+
+import (
+	"testing"
+
+	argocdv1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/gitops-engine/pkg/health"
+	"github.com/int128/argocd-commenter/internal/argocd"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestFilteredSourceRevisionsForHealthComment(t *testing.T) {
+	app := argocdv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-app",
+			Annotations: map[string]string{
+				argocd.AnnotationExcludeRepoURLs: "https://github.com/org/repo-b",
+			},
+		},
+		Spec: argocdv1alpha1.ApplicationSpec{
+			Sources: argocdv1alpha1.ApplicationSources{
+				{RepoURL: "https://github.com/org/repo-a", Path: "apps/a"},
+				{RepoURL: "https://github.com/org/repo-b", Path: "apps/b"},
+			},
+		},
+		Status: argocdv1alpha1.ApplicationStatus{
+			Health: argocdv1alpha1.AppHealthStatus{
+				Status: health.HealthStatusDegraded,
+			},
+			OperationState: &argocdv1alpha1.OperationState{
+				Operation: argocdv1alpha1.Operation{
+					Sync: &argocdv1alpha1.SyncOperation{
+						Revisions: []string{"aaa111", "bbb222"},
+					},
+				},
+			},
+			Resources: []argocdv1alpha1.ResourceStatus{
+				{
+					Namespace: "default",
+					Name:      "my-deploy",
+					Health: &argocdv1alpha1.HealthStatus{
+						Status:  health.HealthStatusDegraded,
+						Message: "deployment not available",
+					},
+				},
+			},
+		},
+	}
+
+	revisions := argocd.GetSourceRevisions(app)
+	filter := argocd.NewRepoURLFilter(app)
+	var count int
+	for _, sr := range revisions {
+		if filter.Allows(sr.Source.RepoURL) {
+			if c := generateCommentOnHealthChanged(app, "https://argocd.example.com", sr); c != nil {
+				count++
+			}
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected 1 comment (repo-b excluded), got %d", count)
+	}
+}

--- a/internal/notification/phasecomment.go
+++ b/internal/notification/phasecomment.go
@@ -22,7 +22,11 @@ var SyncOperationPhasesForComment = []synccommon.OperationPhase{
 func (c client) CreateCommentsOnPhaseChanged(ctx context.Context, app argocdv1alpha1.Application, argocdURL string) error {
 	var errs []error
 	sourceRevisions := argocd.GetSourceRevisions(app)
+	repoFilter := argocd.NewRepoURLFilter(app)
 	for _, sourceRevision := range sourceRevisions {
+		if !repoFilter.Allows(sourceRevision.Source.RepoURL) {
+			continue
+		}
 		comment := generateCommentOnPhaseChanged(app, argocdURL, sourceRevision)
 		if comment == nil {
 			continue

--- a/internal/notification/phasecomment_test.go
+++ b/internal/notification/phasecomment_test.go
@@ -1,0 +1,94 @@
+package notification
+
+import (
+	"testing"
+
+	argocdv1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	synccommon "github.com/argoproj/gitops-engine/pkg/sync/common"
+	"github.com/int128/argocd-commenter/internal/argocd"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGenerateCommentOnPhaseChanged(t *testing.T) {
+	t.Run("generates comment for valid source", func(t *testing.T) {
+		app := argocdv1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-app"},
+			Status: argocdv1alpha1.ApplicationStatus{
+				OperationState: &argocdv1alpha1.OperationState{
+					Phase: synccommon.OperationSucceeded,
+				},
+			},
+		}
+		sr := argocd.SourceRevision{
+			Source:   argocdv1alpha1.ApplicationSource{RepoURL: "https://github.com/org/repo-a"},
+			Revision: "abc123",
+		}
+		comment := generateCommentOnPhaseChanged(app, "https://argocd.example.com", sr)
+		if comment == nil {
+			t.Fatal("expected comment to be generated")
+		}
+		if comment.Body == "" {
+			t.Error("expected non-empty body")
+		}
+	})
+
+	t.Run("returns nil for non-github source", func(t *testing.T) {
+		app := argocdv1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-app"},
+			Status: argocdv1alpha1.ApplicationStatus{
+				OperationState: &argocdv1alpha1.OperationState{
+					Phase: synccommon.OperationSucceeded,
+				},
+			},
+		}
+		sr := argocd.SourceRevision{
+			Source:   argocdv1alpha1.ApplicationSource{RepoURL: "568871113537.dkr.ecr.eu-west-1.amazonaws.com/helm-charts"},
+			Revision: "2.30.0",
+		}
+		comment := generateCommentOnPhaseChanged(app, "https://argocd.example.com", sr)
+		if comment != nil {
+			t.Error("expected nil comment for non-github URL")
+		}
+	})
+}
+
+func TestFilteredSourceRevisionsForPhaseComment(t *testing.T) {
+	app := argocdv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-app",
+			Annotations: map[string]string{
+				argocd.AnnotationExcludeRepoURLs: "https://github.com/org/repo-b",
+			},
+		},
+		Spec: argocdv1alpha1.ApplicationSpec{
+			Sources: argocdv1alpha1.ApplicationSources{
+				{RepoURL: "https://github.com/org/repo-a", Path: "apps/a"},
+				{RepoURL: "https://github.com/org/repo-b", Path: "apps/b"},
+			},
+		},
+		Status: argocdv1alpha1.ApplicationStatus{
+			OperationState: &argocdv1alpha1.OperationState{
+				Phase: synccommon.OperationSucceeded,
+				Operation: argocdv1alpha1.Operation{
+					Sync: &argocdv1alpha1.SyncOperation{
+						Revisions: []string{"aaa111", "bbb222"},
+					},
+				},
+			},
+		},
+	}
+
+	revisions := argocd.GetSourceRevisions(app)
+	filter := argocd.NewRepoURLFilter(app)
+	var count int
+	for _, sr := range revisions {
+		if filter.Allows(sr.Source.RepoURL) {
+			if c := generateCommentOnPhaseChanged(app, "https://argocd.example.com", sr); c != nil {
+				count++
+			}
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected 1 comment (repo-b excluded), got %d", count)
+	}
+}


### PR DESCRIPTION
Added include-repo-urls and exclude-repo-urls annotations to control which source repositories receive PR and commit comments. This prevents ref-only sources (e.g. shared Helm values repos) from being spammed with unrelated comments when their path resolves to "/" and matches every PR file.